### PR TITLE
[#10] Refactor: assert and gettrycount 

### DIFF
--- a/api/src/main/java/com/zzaug/api/domain/member/model/auth/TryCountElement.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/model/auth/TryCountElement.java
@@ -16,8 +16,15 @@ import org.springframework.lang.Nullable;
 @NoArgsConstructor
 @Builder(toBuilder = true)
 public class TryCountElement {
-	private int tryCount;
+
+	private static final int NEW_STATE_TRY_COUNT = 0;
+
+	@Builder.Default private int tryCount = NEW_STATE_TRY_COUNT;
 	@Nullable private Long emailAuthLogId;
+
+	public static TryCountElement newState() {
+		return TryCountElement.builder().build();
+	}
 
 	/**
 	 * 처음 생성된 객체인지 확인합니다.
@@ -25,12 +32,29 @@ public class TryCountElement {
 	 * @return 처음 생성된 객체인지 여부
 	 */
 	public boolean isNew() {
-		return Objects.isNull(emailAuthLogId);
+		if (!Objects.isNull(emailAuthLogId)) {
+			return false;
+		}
+		return true;
 	}
 
 	/** 시도 횟수를 증가시킵니다. */
 	public void plus() {
-		assert !isNew();
+		if (isNew()) {
+			if (isTryCountNewState()) {
+				throw new IllegalStateException("tryCount must be 0 when state is new");
+			}
+			doPlus();
+			return;
+		}
+		doPlus();
+	}
+
+	private void doPlus() {
 		this.tryCount = this.tryCount + 1;
+	}
+
+	private boolean isTryCountNewState() {
+		return !Objects.equals(tryCount, NEW_STATE_TRY_COUNT);
 	}
 }

--- a/api/src/main/java/com/zzaug/api/domain/member/model/auth/TryCountElement.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/model/auth/TryCountElement.java
@@ -18,6 +18,7 @@ import org.springframework.lang.Nullable;
 public class TryCountElement {
 
 	private static final int NEW_STATE_TRY_COUNT = 0;
+	private static final int MAX_TRY_COUNT = 3;
 
 	@Builder.Default private int tryCount = NEW_STATE_TRY_COUNT;
 	@Nullable private Long emailAuthLogId;
@@ -36,6 +37,15 @@ public class TryCountElement {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * 시도 횟수가 최대 시도 횟수를 초과했는지 확인합니다.
+	 *
+	 * @return 시도 횟수가 최대 시도 횟수를 초과했는지 여부
+	 */
+	public boolean isOver() {
+		return tryCount >= MAX_TRY_COUNT;
 	}
 
 	/** 시도 횟수를 증가시킵니다. */

--- a/api/src/main/java/com/zzaug/api/domain/member/service/history/GetEmailAuthCheckTryCountService.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/service/history/GetEmailAuthCheckTryCountService.java
@@ -1,0 +1,8 @@
+package com.zzaug.api.domain.member.service.history;
+
+import com.zzaug.api.domain.member.model.auth.TryCountElement;
+
+public interface GetEmailAuthCheckTryCountService {
+
+	TryCountElement execute(Long memberId, Long emailAuthId);
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/service/history/GetEmailAuthCheckTryCountServiceImpl.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/service/history/GetEmailAuthCheckTryCountServiceImpl.java
@@ -1,0 +1,39 @@
+package com.zzaug.api.domain.member.service.history;
+
+import static com.zzaug.api.domain.member.model.auth.EmailAuthResult.SUCCESS;
+
+import com.zzaug.api.domain.member.dao.history.EmailAutHistoryDao;
+import com.zzaug.api.domain.member.data.entity.history.EmailAuthHistoryEntity;
+import com.zzaug.api.domain.member.model.auth.TryCountElement;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("!usecase-test")
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetEmailAuthCheckTryCountServiceImpl implements GetEmailAuthCheckTryCountService {
+
+	private final EmailAutHistoryDao emailAutHistoryDao;
+
+	@Override
+	@Transactional
+	public TryCountElement execute(Long memberId, Long emailAuthId) {
+		// 이메일 인증을 실패한 이력이 있는지 조회
+		Optional<EmailAuthHistoryEntity> emailAuthLogSource =
+				emailAutHistoryDao.findByMemberIdAndEmailAuthIdAndReasonNotAndDeletedFalse(
+						memberId, emailAuthId, SUCCESS.getReason());
+		if (emailAuthLogSource.isEmpty()) {
+			return TryCountElement.newState();
+		} else {
+			return TryCountElement.builder()
+					.tryCount(Math.toIntExact(emailAuthLogSource.get().getTryCount()))
+					.emailAuthLogId(emailAuthLogSource.get().getId())
+					.build();
+		}
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/service/history/SaveEmailAuthHistoryCommand.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/service/history/SaveEmailAuthHistoryCommand.java
@@ -1,57 +1,10 @@
 package com.zzaug.api.domain.member.service.history;
 
-import com.zzaug.api.domain.member.dao.history.EmailAutHistoryDao;
 import com.zzaug.api.domain.member.data.entity.history.EmailAuthHistoryEntity;
 import com.zzaug.api.domain.member.model.auth.TryCountElement;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class SaveEmailAuthHistoryCommand {
+public interface SaveEmailAuthHistoryCommand {
 
-	private final EmailAutHistoryDao emailAutHistoryDao;
-
-	@Transactional
-	public EmailAuthHistoryEntity execute(
-			TryCountElement tryCount, Long memberId, Long emailAuthId, String reason) {
-		if (tryCount.isNew()) {
-			return save(
-					tryCount.getEmailAuthLogId(),
-					memberId,
-					emailAuthId,
-					reason,
-					(long) tryCount.getTryCount());
-		} else {
-			return save(memberId, emailAuthId, reason, (long) tryCount.getTryCount());
-		}
-	}
-
-	private EmailAuthHistoryEntity save(
-			Long memberId, Long emailAuthId, String reason, Long tryCount) {
-		EmailAuthHistoryEntity emailAuthHistoryEntity =
-				EmailAuthHistoryEntity.builder()
-						.memberId(memberId)
-						.emailAuthId(emailAuthId)
-						.reason(reason)
-						.tryCount(tryCount)
-						.build();
-		return emailAutHistoryDao.saveEmailAuthLog(emailAuthHistoryEntity);
-	}
-
-	private EmailAuthHistoryEntity save(
-			Long id, Long memberId, Long emailAuthId, String reason, Long tryCount) {
-		EmailAuthHistoryEntity emailAuthHistoryEntity =
-				EmailAuthHistoryEntity.builder()
-						.id(id)
-						.memberId(memberId)
-						.emailAuthId(emailAuthId)
-						.reason(reason)
-						.tryCount(tryCount)
-						.build();
-		return emailAutHistoryDao.saveEmailAuthLog(emailAuthHistoryEntity);
-	}
+	EmailAuthHistoryEntity execute(
+			TryCountElement tryCount, Long memberId, Long emailAuthId, String reason);
 }

--- a/api/src/main/java/com/zzaug/api/domain/member/service/history/SaveEmailAuthHistoryCommandImpl.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/service/history/SaveEmailAuthHistoryCommandImpl.java
@@ -1,0 +1,60 @@
+package com.zzaug.api.domain.member.service.history;
+
+import com.zzaug.api.domain.member.dao.history.EmailAutHistoryDao;
+import com.zzaug.api.domain.member.data.entity.history.EmailAuthHistoryEntity;
+import com.zzaug.api.domain.member.model.auth.TryCountElement;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("!usecase-test")
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SaveEmailAuthHistoryCommandImpl implements SaveEmailAuthHistoryCommand {
+
+	private final EmailAutHistoryDao emailAutHistoryDao;
+
+	@Override
+	@Transactional
+	public EmailAuthHistoryEntity execute(
+			TryCountElement tryCount, Long memberId, Long emailAuthId, String reason) {
+		if (tryCount.isNew()) {
+			return save(
+					tryCount.getEmailAuthLogId(),
+					memberId,
+					emailAuthId,
+					reason,
+					(long) tryCount.getTryCount());
+		} else {
+			return save(memberId, emailAuthId, reason, (long) tryCount.getTryCount());
+		}
+	}
+
+	private EmailAuthHistoryEntity save(
+			Long memberId, Long emailAuthId, String reason, Long tryCount) {
+		EmailAuthHistoryEntity emailAuthHistoryEntity =
+				EmailAuthHistoryEntity.builder()
+						.memberId(memberId)
+						.emailAuthId(emailAuthId)
+						.reason(reason)
+						.tryCount(tryCount)
+						.build();
+		return emailAutHistoryDao.saveEmailAuthLog(emailAuthHistoryEntity);
+	}
+
+	private EmailAuthHistoryEntity save(
+			Long id, Long memberId, Long emailAuthId, String reason, Long tryCount) {
+		EmailAuthHistoryEntity emailAuthHistoryEntity =
+				EmailAuthHistoryEntity.builder()
+						.id(id)
+						.memberId(memberId)
+						.emailAuthId(emailAuthId)
+						.reason(reason)
+						.tryCount(tryCount)
+						.build();
+		return emailAutHistoryDao.saveEmailAuthLog(emailAuthHistoryEntity);
+	}
+}

--- a/api/src/test/java/com/zzaug/api/domain/member/data/persistence/member/MemberRepositoryTest.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/data/persistence/member/MemberRepositoryTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.zzaug.api.domain.member.data.entity.member.MemberEntity;
 import com.zzaug.api.domain.member.data.entity.member.MemberStatus;
 import com.zzaug.api.domain.member.data.persistence.AbstractRepositoryTest;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +23,9 @@ class MemberRepositoryTest extends AbstractRepositoryTest {
 		MemberEntity entity = MemberEntity.builder().build();
 		repository.save(entity);
 		memberId = entity.getId();
-		assert memberId != 0L;
+		if (Objects.compare(memberId, 0L, Comparator.naturalOrder()) == 0) {
+			throw new RuntimeException("멤버 아이디가 생성되지 않았습니다.");
+		}
 	}
 
 	@Test

--- a/api/src/test/java/com/zzaug/api/domain/member/model/auth/TryCountElementTest.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/model/auth/TryCountElementTest.java
@@ -1,0 +1,61 @@
+package com.zzaug.api.domain.member.model.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TryCountElementTest {
+
+	@Test
+	void 처음_생성된_객체인지_확인합니다() {
+		// given
+		TryCountElement newState = TryCountElement.newState();
+
+		// when
+		boolean result = newState.isNew();
+
+		// then
+		assertTrue(result);
+	}
+
+	@Test
+	void 시도_횟수가_최대_시도_횟수를_초과했는지_확인합니다() {
+		// given
+		int maxTryCount = 3;
+		TryCountElement tryCountElement = TryCountElement.builder().tryCount(maxTryCount).build();
+
+		// when
+		boolean result = tryCountElement.isOver();
+
+		// then
+		assertTrue(result);
+	}
+
+	@Test
+	void 시도_횟수를_증가시킵니다() {
+		// given
+		int givenTryCount = 0;
+		TryCountElement tryCountElement = TryCountElement.builder().tryCount(givenTryCount).build();
+
+		// when
+		tryCountElement.plus();
+
+		// then
+		assertEquals(givenTryCount + 1, tryCountElement.getTryCount());
+	}
+
+	@Test
+	void 새로운_상태에서_시도_횟수를_여러번_증가시키면_예외가_발생합니다() {
+		// given
+		TryCountElement newState = TryCountElement.newState();
+
+		// when
+		newState.plus();
+
+		// then
+		assertThrows(IllegalStateException.class, newState::plus);
+	}
+}

--- a/api/src/test/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCaseTest.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCaseTest.java
@@ -6,10 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.zzaug.api.ApiApp;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseRequest;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseResponse;
-import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockEmailAutHistoryDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockEmailAuthDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockExternalContactDao;
+import com.zzaug.api.domain.member.usecase.config.mock.service.UMcokGetEmailAuthCheckTryCountService;
 import com.zzaug.api.domain.member.usecase.config.mock.service.UMockGetMemberSourceQuery;
+import com.zzaug.api.domain.member.usecase.config.mock.service.UMockSaveEmailAuthHistoryCommand;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 			ApiApp.class,
 			UMockExternalContactDao.class,
 			UMockEmailAuthDao.class,
-			UMockEmailAutHistoryDao.class,
 			UMockGetMemberSourceQuery.class,
+			UMcokGetEmailAuthCheckTryCountService.class,
+			UMockSaveEmailAuthHistoryCommand.class,
 		})
 class CheckEmailAuthUseCaseTest extends AbstractUseCaseTest {
 

--- a/api/src/test/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT.java
@@ -6,10 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import com.zzaug.api.ApiApp;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseRequest;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseResponse;
-import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockEmailAutHistoryDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockEmailAuthDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockExternalContactDao;
+import com.zzaug.api.domain.member.usecase.config.mock.service.UMcokGetEmailAuthCheckTryCountService;
 import com.zzaug.api.domain.member.usecase.config.mock.service.UMockGetMemberSourceQuery;
+import com.zzaug.api.domain.member.usecase.config.mock.service.UMockSaveEmailAuthHistoryCommand;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,8 +24,9 @@ import org.springframework.test.context.ActiveProfiles;
 			ApiApp.class,
 			UMockExternalContactDao.class,
 			UMockEmailAuthDao.class,
-			UMockEmailAutHistoryDao.class,
-			UMockGetMemberSourceQuery.class
+			UMockGetMemberSourceQuery.class,
+			UMcokGetEmailAuthCheckTryCountService.class,
+			UMockSaveEmailAuthHistoryCommand.class,
 		})
 class CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 
@@ -61,6 +63,8 @@ class CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 		// Then
 		org.junit.jupiter.api.Assertions.assertAll(
 				() -> assertFalse(response.getAuthentication()),
-				() -> assertThat(response.getTryCount()).isEqualTo(UMockEmailAutHistoryDao.MAX_TRY_COUNT));
+				() ->
+						assertThat(response.getTryCount())
+								.isEqualTo(UMcokGetEmailAuthCheckTryCountService.MAX_TRY_COUNT));
 	}
 }

--- a/api/src/test/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT.java
@@ -6,10 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.zzaug.api.ApiApp;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseRequest;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseResponse;
-import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockEmailAutHistoryDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockEmailAuthDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockExternalContactDao;
+import com.zzaug.api.domain.member.usecase.config.mock.service.UMcokGetEmailAuthCheckTryCountService;
 import com.zzaug.api.domain.member.usecase.config.mock.service.UMockGetMemberSourceQuery;
+import com.zzaug.api.domain.member.usecase.config.mock.service.UMockSaveEmailAuthHistoryCommand;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,9 @@ import org.springframework.test.context.ActiveProfiles;
 			ApiApp.class,
 			UMockExternalContactDao.class,
 			UMockEmailAuthDao.class,
-			UMockEmailAutHistoryDao.class,
-			UMockGetMemberSourceQuery.class
+			UMockGetMemberSourceQuery.class,
+			UMcokGetEmailAuthCheckTryCountService.class,
+			UMockSaveEmailAuthHistoryCommand.class,
 		})
 class CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 
@@ -61,7 +63,7 @@ class CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 		// Then
 		assertTrue(response.getAuthentication());
 		Assertions.assertThat(response.getTryCount())
-				.isEqualTo(UMockEmailAutHistoryDao.UNDER_MAX_TRY_COUNT);
+				.isEqualTo(UMcokGetEmailAuthCheckTryCountService.UNDER_MAX_TRY_COUNT);
 	}
 
 	@Test
@@ -81,6 +83,6 @@ class CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 		// Then
 		assertFalse(response.getAuthentication());
 		Assertions.assertThat(response.getTryCount())
-				.isEqualTo(UMockEmailAutHistoryDao.UNDER_MAX_TRY_COUNT + 1);
+				.isEqualTo(UMcokGetEmailAuthCheckTryCountService.UNDER_MAX_TRY_COUNT + 1);
 	}
 }

--- a/api/src/test/java/com/zzaug/api/domain/member/usecase/config/mock/service/UMcokGetEmailAuthCheckTryCountService.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/usecase/config/mock/service/UMcokGetEmailAuthCheckTryCountService.java
@@ -1,0 +1,57 @@
+package com.zzaug.api.domain.member.usecase.config.mock.service;
+
+import com.zzaug.api.domain.member.model.auth.TryCountElement;
+import com.zzaug.api.domain.member.service.history.GetEmailAuthCheckTryCountService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeansException;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * 테스트용 이메일 인증 확인 시도 횟수 조회 서비스
+ *
+ * <p>프로파일이 설정되지 않은 경우 인증 시도 횟수가 0회입니다.
+ *
+ * <p>프로파일이 over-max-try-count인 경우 인증 시도 횟수가 3회입니다.
+ *
+ * <p>프로파일이 under-max-try-count인 경우 인증 시도 횟수가 2회입니다.
+ */
+@Profile("usecase-test")
+@TestComponent
+@RequiredArgsConstructor
+public class UMcokGetEmailAuthCheckTryCountService
+		implements GetEmailAuthCheckTryCountService, ApplicationContextAware {
+
+	public static final Long EMAIL_AUTH_LOG_ID = 1L;
+
+	public static final Long INITIAL_TRY_COUNT = 0L;
+	public static final Long UNDER_MAX_TRY_COUNT = 2L;
+	public static final Long MAX_TRY_COUNT = 3L;
+
+	private List<String> activeProfiles;
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		activeProfiles = List.of(applicationContext.getEnvironment().getActiveProfiles());
+	}
+
+	@Override
+	public TryCountElement execute(Long memberId, Long emailAuthId) {
+		if (activeProfiles.contains("under-max-try-count")) {
+			return TryCountElement.builder()
+					.tryCount(Math.toIntExact(UNDER_MAX_TRY_COUNT))
+					.emailAuthLogId(EMAIL_AUTH_LOG_ID)
+					.build();
+		}
+		if (activeProfiles.contains("over-max-try-count")) {
+			return TryCountElement.builder()
+					.tryCount(Math.toIntExact(MAX_TRY_COUNT))
+					.emailAuthLogId(EMAIL_AUTH_LOG_ID)
+					.build();
+		}
+		return TryCountElement.builder().tryCount(Math.toIntExact(INITIAL_TRY_COUNT)).build();
+	}
+}

--- a/api/src/test/java/com/zzaug/api/domain/member/usecase/config/mock/service/UMockSaveEmailAuthHistoryCommand.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/usecase/config/mock/service/UMockSaveEmailAuthHistoryCommand.java
@@ -1,0 +1,50 @@
+package com.zzaug.api.domain.member.usecase.config.mock.service;
+
+import com.zzaug.api.domain.member.data.entity.history.EmailAuthHistoryEntity;
+import com.zzaug.api.domain.member.model.auth.TryCountElement;
+import com.zzaug.api.domain.member.service.history.SaveEmailAuthHistoryCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.annotation.Profile;
+
+@Profile("usecase-test")
+@TestComponent
+@RequiredArgsConstructor
+public class UMockSaveEmailAuthHistoryCommand implements SaveEmailAuthHistoryCommand {
+
+	@Override
+	public EmailAuthHistoryEntity execute(
+			TryCountElement tryCount, Long memberId, Long emailAuthId, String reason) {
+		if (tryCount.isNew()) {
+			return save(
+					tryCount.getEmailAuthLogId(),
+					memberId,
+					emailAuthId,
+					reason,
+					(long) tryCount.getTryCount());
+		} else {
+			return save(memberId, emailAuthId, reason, (long) tryCount.getTryCount());
+		}
+	}
+
+	private EmailAuthHistoryEntity save(
+			Long memberId, Long emailAuthId, String reason, Long tryCount) {
+		return EmailAuthHistoryEntity.builder()
+				.memberId(memberId)
+				.emailAuthId(emailAuthId)
+				.reason(reason)
+				.tryCount(tryCount)
+				.build();
+	}
+
+	private EmailAuthHistoryEntity save(
+			Long id, Long memberId, Long emailAuthId, String reason, Long tryCount) {
+		return EmailAuthHistoryEntity.builder()
+				.id(id)
+				.memberId(memberId)
+				.emailAuthId(emailAuthId)
+				.reason(reason)
+				.tryCount(tryCount)
+				.build();
+	}
+}


### PR DESCRIPTION
🎫 연관 티켓
---
#10

🙏 작업
----
- CheckEmailAuthUseCase#getTryCount 예외 던지지 않는 방식으로 수정합니다.
- assert 활용한 검증을 수정합니다.

💁‍♂️ 어떻게?
----
## CheckEmailAuthUseCase#getTryCount 예외 던지지 않는 방식으로 수정합니다.

기존에 구현된 TryCountElement를 보충하였습니다.
TryCountElement의 emailAuthLogId는 tryCount 초기화 되는 시점이 다릅니다.
우선 `@Nullable`을 통해 이를 명시하였고 추후 리펙토링할 예정입니다.

TryCountElement#isOver을 활용하여 예외를 던지지 않고 확인할 수 있는 방법으로 수정하였습니다.

## assert 활용한 검증을 수정합니다.

assert를 활용한 검증의 경우 예외 메시지를 설정할 수 없는 단점이 존재하여 이를 수정하였습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
