### PR TITLE
[#4] Feat: custom exception

### DIFF
--- a/api/src/main/java/com/zzaug/api/domain/member/exception/argument/NotMatchEmailAuthException.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/exception/argument/NotMatchEmailAuthException.java
@@ -1,0 +1,8 @@
+package com.zzaug.api.domain.member.exception.argument;
+
+public class NotMatchEmailAuthException extends IllegalArgumentException {
+
+	public NotMatchEmailAuthException() {
+		super("Not Match Email Auth");
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/exception/argument/NotMatchMemberException.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/exception/argument/NotMatchMemberException.java
@@ -1,0 +1,8 @@
+package com.zzaug.api.domain.member.exception.argument;
+
+public class NotMatchMemberException extends IllegalArgumentException {
+
+	public NotMatchMemberException() {
+		super("Not Match Member");
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/exception/argument/NotMatchPasswordException.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/exception/argument/NotMatchPasswordException.java
@@ -1,0 +1,8 @@
+package com.zzaug.api.domain.member.exception.argument;
+
+public class NotMatchPasswordException extends IllegalArgumentException {
+
+	public NotMatchPasswordException() {
+		super("Not Match Password");
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/exception/state/DuplicateCertificationException.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/exception/state/DuplicateCertificationException.java
@@ -1,0 +1,8 @@
+package com.zzaug.api.domain.member.exception.state;
+
+public class DuplicateCertificationException extends IllegalStateException {
+
+	public DuplicateCertificationException() {
+		super("Duplicate Certification");
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/exception/strategy/IllegalMemberRequestStrategyException.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/exception/strategy/IllegalMemberRequestStrategyException.java
@@ -1,0 +1,8 @@
+package com.zzaug.api.domain.member.exception.strategy;
+
+public class IllegalMemberRequestStrategyException extends IllegalRequestStrategyException {
+
+	public IllegalMemberRequestStrategyException() {
+		super("Illegal Member Request Strategy");
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/exception/strategy/IllegalNonceRequestStrategyException.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/exception/strategy/IllegalNonceRequestStrategyException.java
@@ -1,0 +1,8 @@
+package com.zzaug.api.domain.member.exception.strategy;
+
+public class IllegalNonceRequestStrategyException extends IllegalRequestStrategyException {
+
+	public IllegalNonceRequestStrategyException() {
+		super("Illegal Nonce Request Strategy");
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/exception/strategy/IllegalRequestStrategyException.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/exception/strategy/IllegalRequestStrategyException.java
@@ -1,0 +1,23 @@
+package com.zzaug.api.domain.member.exception.strategy;
+
+/**
+ * 요청 전략이 잘못된 경우
+ *
+ * <p>발생하는 예외 해당 예외의 경우 그 책임이 사용자가 아닌 개발자에게 있음
+ */
+public abstract class IllegalRequestStrategyException extends IllegalArgumentException {
+
+	public IllegalRequestStrategyException() {}
+
+	public IllegalRequestStrategyException(String s) {
+		super(s);
+	}
+
+	public IllegalRequestStrategyException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public IllegalRequestStrategyException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/api/src/main/java/com/zzaug/api/domain/member/service/member/GetRegularMemberSourceQuery.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/service/member/GetRegularMemberSourceQuery.java
@@ -3,6 +3,7 @@ package com.zzaug.api.domain.member.service.member;
 import com.zzaug.api.domain.member.dao.member.MemberSourceDao;
 import com.zzaug.api.domain.member.data.entity.member.MemberEntity;
 import com.zzaug.api.domain.member.data.entity.member.MemberStatus;
+import com.zzaug.api.domain.member.exception.argument.NotMatchMemberException;
 import com.zzaug.api.domain.member.model.member.MemberSource;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class GetRegularMemberSourceQuery implements GetMemberSourceQuery {
 		Optional<MemberEntity> entity =
 				memberRepository.findByIdAndStatusAndDeletedFalse(memberId, MemberStatus.REGULAR);
 		if (entity.isEmpty()) {
-			throw new IllegalArgumentException();
+			throw new NotMatchMemberException();
 		}
 		MemberEntity source = entity.get();
 		return new MemberSource(source.getId());

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/CheckEmailAuthUseCase.java
@@ -10,6 +10,9 @@ import com.zzaug.api.domain.member.data.entity.history.EmailAuthHistoryEntity;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseRequest;
 import com.zzaug.api.domain.member.dto.CheckEmailAuthUseCaseResponse;
 import com.zzaug.api.domain.member.dto.SuccessCheckEmailAuthUseCaseResponse;
+import com.zzaug.api.domain.member.exception.argument.NotMatchEmailAuthException;
+import com.zzaug.api.domain.member.exception.strategy.IllegalMemberRequestStrategyException;
+import com.zzaug.api.domain.member.exception.strategy.IllegalNonceRequestStrategyException;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthToken;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthTokenGenerator;
 import com.zzaug.api.domain.member.model.auth.EmailAuthResult;
@@ -56,13 +59,11 @@ public class CheckEmailAuthUseCase {
 
 		// 이메일 인증 확인 요청한 멤버와 해당 API를 요청한 멤버가 일치하는지 확인
 		if (!emailAuth.isMemberId(memberSource.getId())) {
-			// todo refactor: 서버, 프론트간 비정상적인 요청 예외로 처리
-			throw new IllegalArgumentException();
+			throw new IllegalMemberRequestStrategyException();
 		}
 		// 이메일 인증 요청시 발급한 nonce와 요청한 nonce가 일치하는지 확인
 		if (!emailAuth.isNonce(nonce)) {
-			// todo refactor: 서버, 프론트간 비정상적인 요청 예외로 처리
-			throw new IllegalArgumentException();
+			throw new IllegalNonceRequestStrategyException();
 		}
 
 		// 이메일 인증을 시도한 횟수를 조회
@@ -107,7 +108,7 @@ public class CheckEmailAuthUseCase {
 				emailAuthDao.findByMemberIdAndEmailAndNonceAndDeletedFalse(
 						memberSource.getId(), email, nonce);
 		if (emailAuthSource.isEmpty()) {
-			throw new IllegalArgumentException();
+			throw new NotMatchEmailAuthException();
 		}
 		return EmailAuthSourceConverter.from(emailAuthSource.get());
 	}

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/DeleteMemberUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/DeleteMemberUseCase.java
@@ -4,6 +4,7 @@ import com.zzaug.api.domain.member.dao.member.MemberSourceDao;
 import com.zzaug.api.domain.member.data.entity.member.MemberEntity;
 import com.zzaug.api.domain.member.data.entity.member.MemberStatus;
 import com.zzaug.api.domain.member.dto.DeleteMemberUseCaseRequest;
+import com.zzaug.api.domain.member.exception.strategy.IllegalMemberRequestStrategyException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,8 +26,7 @@ public class DeleteMemberUseCase {
 		Optional<MemberEntity> memberSource =
 				memberSourceDao.findByIdAndStatusAndDeletedFalse(memberId, MemberStatus.REGULAR);
 		if (memberSource.isEmpty()) {
-			// todo refactor: 서버, 프론트간 비정상적인 요청 예외로 처리
-			throw new IllegalArgumentException();
+			throw new IllegalMemberRequestStrategyException();
 		}
 
 		MemberEntity memberEntity = memberSource.get();

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/LoginUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/LoginUseCase.java
@@ -7,6 +7,8 @@ import com.zzaug.api.domain.member.data.entity.member.CertificationData;
 import com.zzaug.api.domain.member.data.entity.member.PasswordData;
 import com.zzaug.api.domain.member.dto.LoginUseCaseRequest;
 import com.zzaug.api.domain.member.dto.MemberAuthToken;
+import com.zzaug.api.domain.member.exception.argument.NotMatchMemberException;
+import com.zzaug.api.domain.member.exception.argument.NotMatchPasswordException;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthToken;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthTokenGenerator;
 import com.zzaug.api.domain.member.model.member.MemberAuthentication;
@@ -37,14 +39,14 @@ public class LoginUseCase {
 		Optional<AuthenticationEntity> authenticationSource =
 				authenticationDao.findByCertificationAndDeletedFalse(certification);
 		if (authenticationSource.isEmpty()) {
-			throw new IllegalArgumentException();
+			throw new NotMatchMemberException();
 		}
 		MemberAuthentication memberAuthentication =
 				MemberAuthenticationConverter.from(authenticationSource.get());
 
 		// 비밀번호 일치 여부 확인
 		if (!memberAuthentication.isMatchPassword(passwordEncoder, password.getPassword())) {
-			throw new IllegalArgumentException();
+			throw new NotMatchPasswordException();
 		}
 
 		// 인증 토큰 생성

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/PostMemberUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/PostMemberUseCase.java
@@ -8,6 +8,7 @@ import com.zzaug.api.domain.member.data.entity.member.MemberEntity;
 import com.zzaug.api.domain.member.data.entity.member.PasswordData;
 import com.zzaug.api.domain.member.dto.PostMemberUseCaseRequest;
 import com.zzaug.api.domain.member.dto.PostMemberUseCaseResponse;
+import com.zzaug.api.domain.member.exception.state.DuplicateCertificationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -34,7 +35,7 @@ public class PostMemberUseCase {
 		boolean isDuplicateCertification =
 				authenticationDao.existsByCertificationAndDeletedFalse(certification);
 		if (isDuplicateCertification) {
-			throw new IllegalArgumentException();
+			throw new DuplicateCertificationException();
 		}
 
 		// 비밀번호 암호화

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/RenewalTokenUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/RenewalTokenUseCase.java
@@ -4,6 +4,7 @@ import com.zzaug.api.domain.member.dao.member.AuthenticationDao;
 import com.zzaug.api.domain.member.data.entity.member.AuthenticationEntity;
 import com.zzaug.api.domain.member.dto.MemberAuthToken;
 import com.zzaug.api.domain.member.dto.RenewalTokenUseCaseRequest;
+import com.zzaug.api.domain.member.exception.strategy.IllegalMemberRequestStrategyException;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthToken;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthTokenGenerator;
 import com.zzaug.api.domain.member.model.member.MemberSource;
@@ -35,8 +36,7 @@ public class RenewalTokenUseCase {
 		Optional<AuthenticationEntity> authenticationSource =
 				authenticationDao.findByMemberIdAndDeletedFalse(memberId);
 		if (authenticationSource.isEmpty()) {
-			// todo refactor: 서버, 프론트간 비정상적인 요청 예외로 처리
-			throw new IllegalArgumentException();
+			throw new IllegalMemberRequestStrategyException();
 		}
 
 		RoleUserAuthToken authToken = roleUserAuthTokenGenerator.generateToken(memberSource.getId());

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/UpdateMemberUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/UpdateMemberUseCase.java
@@ -6,6 +6,7 @@ import com.zzaug.api.domain.member.data.entity.member.AuthenticationEntity;
 import com.zzaug.api.domain.member.data.entity.member.CertificationData;
 import com.zzaug.api.domain.member.dto.UpdateMemberUseCaseRequest;
 import com.zzaug.api.domain.member.dto.UpdateMemberUseCaseResponse;
+import com.zzaug.api.domain.member.exception.strategy.IllegalMemberRequestStrategyException;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthToken;
 import com.zzaug.api.domain.member.external.security.token.RoleUserAuthTokenGenerator;
 import com.zzaug.api.domain.member.model.member.MemberAuthentication;
@@ -44,8 +45,7 @@ public class UpdateMemberUseCase {
 		Optional<AuthenticationEntity> authenticationSource =
 				authenticationDao.findByMemberIdAndDeletedFalse(memberSource.getId());
 		if (authenticationSource.isEmpty()) {
-			// todo refactor: 서버, 프론트간 비정상적인 요청 예외로 처리
-			throw new IllegalArgumentException();
+			throw new IllegalMemberRequestStrategyException();
 		}
 		MemberAuthentication memberAuthentication =
 				MemberAuthenticationConverter.from(authenticationSource.get());

--- a/api/src/main/java/com/zzaug/api/web/handler/ApiControllerExceptionHandler.java
+++ b/api/src/main/java/com/zzaug/api/web/handler/ApiControllerExceptionHandler.java
@@ -6,6 +6,7 @@ import static com.zzaug.api.web.handler.ExceptionMessage.FAIL_NOT_FOUND;
 import static com.zzaug.api.web.handler.ExceptionMessage.FAIL_REQUEST;
 import static com.zzaug.api.web.handler.ExceptionMessage.REQUEST_INVALID_FORMAT;
 
+import com.zzaug.api.domain.member.exception.strategy.IllegalRequestStrategyException;
 import com.zzaug.api.web.support.ApiResponse;
 import com.zzaug.api.web.support.ApiResponse.FailureBody;
 import com.zzaug.api.web.support.ApiResponseGenerator;
@@ -118,6 +119,23 @@ public class ApiControllerExceptionHandler {
 		ValidationException rex = ex;
 		return ApiResponseGenerator.fail(
 				FAIL_REQUEST.getCode(), FAIL_REQUEST.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(IllegalStateException.class)
+	public ApiResponse<FailureBody> handleIllegalState(
+			final Exception ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		return ApiResponseGenerator.fail(
+				FAIL.getCode(), FAIL.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@ExceptionHandler(IllegalRequestStrategyException.class)
+	public ApiResponse<FailureBody> handleIllegalRequestStrategy(
+			final Exception ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		// todo feat: 외부 알림 서비스 연동 기능 추가
+		return ApiResponseGenerator.fail(
+				FAIL.getCode(), FAIL.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
 	@ExceptionHandler({NoHandlerFoundException.class})

--- a/api/src/test/java/com/zzaug/api/domain/member/usecase/PostMemberUseCaseTest_EXIST_CERTIFICATION.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/usecase/PostMemberUseCaseTest_EXIST_CERTIFICATION.java
@@ -2,6 +2,7 @@ package com.zzaug.api.domain.member.usecase;
 
 import com.zzaug.api.ApiApp;
 import com.zzaug.api.domain.member.dto.PostMemberUseCaseRequest;
+import com.zzaug.api.domain.member.exception.state.DuplicateCertificationException;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockAuthenticationDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockMemberSourceDao;
 import org.assertj.core.api.Assertions;
@@ -25,6 +26,6 @@ class PostMemberUseCaseTest_EXIST_CERTIFICATION extends AbstractUseCaseTest {
 						.build();
 
 		Assertions.assertThatThrownBy(() -> postMemberUseCase.execute(request))
-				.isInstanceOf(IllegalArgumentException.class);
+				.isInstanceOf(DuplicateCertificationException.class);
 	}
 }


### PR DESCRIPTION
🎫 연관 티켓
---
#4

🙏 작업
----
- 일반 예외를 상속하여 선언한 커스텀 예외를 적용하였습니다.

💁‍♂️ 어떻게?
----
## 일반 예외를 상속하여 선언한 커스텀 예외를 적용하였습니다.

커스텀 예외를 사용해야하는 이유는 일반 예외를 사용하면 예외를 구분하여 처리할 수 없고 어떠한 예외인지 명시적으로 나타내기 힘들기 때문입니다.

구분하여 처리 -> `ApiControllerExceptionHandler`에서 구분하여 처리하고 있습니다.

🙈 PR 참고 사항
----


📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
