### PR TITLE
[#7] Refactor: searchmemberusecase response

### DIFF
--- a/api/src/main/java/com/zzaug/api/domain/member/dto/SearchMemberUseCaseResponse.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/dto/SearchMemberUseCaseResponse.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.util.Strings;
 public class SearchMemberUseCaseResponse {
 
 	private Long id;
+	private String certification;
 	private String email;
 	private String github;
 
@@ -24,6 +25,7 @@ public class SearchMemberUseCaseResponse {
 	public static SearchMemberUseCaseResponse notExistSearchTarget() {
 		return SearchMemberUseCaseResponse.builder()
 				.id(Long.MIN_VALUE)
+				.certification(Strings.EMPTY)
 				.email(Strings.EMPTY)
 				.github(Strings.EMPTY)
 				.build();

--- a/api/src/main/java/com/zzaug/api/domain/member/dto/SearchMemberUseCaseResponse.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/dto/SearchMemberUseCaseResponse.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.apache.logging.log4j.util.Strings;
 
 @Getter
 @ToString
@@ -18,4 +19,13 @@ public class SearchMemberUseCaseResponse {
 	private Long id;
 	private String email;
 	private String github;
+
+	/** 검색 대상이 존재하지 않을 때 반환하는 응답 */
+	public static SearchMemberUseCaseResponse notExistSearchTarget() {
+		return SearchMemberUseCaseResponse.builder()
+				.id(Long.MIN_VALUE)
+				.email(Strings.EMPTY)
+				.github(Strings.EMPTY)
+				.build();
+	}
 }

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/SearchMemberUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/SearchMemberUseCase.java
@@ -7,7 +7,7 @@ import com.zzaug.api.domain.member.data.entity.member.CertificationData;
 import com.zzaug.api.domain.member.data.entity.member.ExternalContactEntity;
 import com.zzaug.api.domain.member.dto.SearchMemberUseCaseRequest;
 import com.zzaug.api.domain.member.dto.SearchMemberUseCaseResponse;
-import com.zzaug.api.domain.member.model.member.GetMemberId;
+import com.zzaug.api.domain.member.model.member.MemberAuthentication;
 import com.zzaug.api.domain.member.model.member.MemberContacts;
 import com.zzaug.api.domain.member.util.entity.MemberAuthenticationConverter;
 import com.zzaug.api.domain.member.util.entity.MemberContactExtractor;
@@ -36,16 +36,16 @@ public class SearchMemberUseCase {
 		if (authenticationSource.isEmpty()) {
 			return SearchMemberUseCaseResponse.notExistSearchTarget();
 		}
-		GetMemberId memberAuthentication =
+		MemberAuthentication memberAuthentication =
 				MemberAuthenticationConverter.from(authenticationSource.get());
 
 		List<ExternalContactEntity> contacts =
 				externalContactDao.findAllByMemberIdAndDeletedFalse(memberAuthentication.getMemberId());
 		MemberContacts memberContacts = MemberContactExtractor.execute(contacts);
 
-		// todo refactor: Certification도 포함될 수 있도록 수정
 		return SearchMemberUseCaseResponse.builder()
 				.id(memberAuthentication.getMemberId())
+				.certification(memberAuthentication.getCertification())
 				.email(memberContacts.getEmail())
 				.github(memberContacts.getGithub())
 				.build();

--- a/api/src/main/java/com/zzaug/api/domain/member/usecase/SearchMemberUseCase.java
+++ b/api/src/main/java/com/zzaug/api/domain/member/usecase/SearchMemberUseCase.java
@@ -34,8 +34,7 @@ public class SearchMemberUseCase {
 		Optional<AuthenticationEntity> authenticationSource =
 				authenticationDao.findByCertificationAndDeletedFalse(certification);
 		if (authenticationSource.isEmpty()) {
-			// todo fix: EMPTY STRING으로 채워진 객체 반환하도록 수정
-			throw new IllegalArgumentException();
+			return SearchMemberUseCaseResponse.notExistSearchTarget();
 		}
 		GetMemberId memberAuthentication =
 				MemberAuthenticationConverter.from(authenticationSource.get());

--- a/api/src/test/java/com/zzaug/api/domain/member/usecase/SearchMemberUseCaseTest_NOT_EXIST_CERTIFICATION.java
+++ b/api/src/test/java/com/zzaug/api/domain/member/usecase/SearchMemberUseCaseTest_NOT_EXIST_CERTIFICATION.java
@@ -2,6 +2,7 @@ package com.zzaug.api.domain.member.usecase;
 
 import com.zzaug.api.ApiApp;
 import com.zzaug.api.domain.member.dto.SearchMemberUseCaseRequest;
+import com.zzaug.api.domain.member.dto.SearchMemberUseCaseResponse;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockAuthenticationDao;
 import com.zzaug.api.domain.member.usecase.config.mock.repository.UMockExternalContactDao;
 import org.assertj.core.api.Assertions;
@@ -24,7 +25,9 @@ class SearchMemberUseCaseTest_NOT_EXIST_CERTIFICATION extends AbstractUseCaseTes
 				SearchMemberUseCaseRequest.builder().certification("notExist").build();
 
 		// When
-		Assertions.assertThatThrownBy(() -> searchMemberUseCase.execute(request))
-				.isInstanceOf(IllegalArgumentException.class);
+		SearchMemberUseCaseResponse response = searchMemberUseCase.execute(request);
+
+		// Then
+		Assertions.assertThat(response).isEqualTo(SearchMemberUseCaseResponse.notExistSearchTarget());
 	}
 }

--- a/api/src/test/java/com/zzaug/api/web/controller/v1/member/MemberControllerTest.java
+++ b/api/src/test/java/com/zzaug/api/web/controller/v1/member/MemberControllerTest.java
@@ -306,6 +306,7 @@ class MemberControllerTest {
 				.thenReturn(
 						SearchMemberUseCaseResponse.builder()
 								.id(1L)
+								.certification("certification")
 								.email("sample@email.com")
 								.github("github")
 								.build());
@@ -339,6 +340,9 @@ class MemberControllerTest {
 																	fieldWithPath("data.id")
 																			.type(JsonFieldType.NUMBER)
 																			.description("멤버 아이디"),
+																	fieldWithPath("data.certification")
+																			.type(JsonFieldType.STRING)
+																			.description("멤버 증명(아이디)"),
 																	fieldWithPath("data.email")
 																			.type(JsonFieldType.STRING)
 																			.description("멤버 이메일"),


### PR DESCRIPTION
🎫 연관 티켓
---
#7

🙏 작업
----
- SearchMemberUseCase 반환을 수정하였습니다.

💁‍♂️ 어떻게?
----
## SearchMemberUseCase 반환을 수정하였습니다.

SearchMemberUseCaseResponse에 certification 멤버를 추가하였습니다.

SearchMemberUseCase의 수행 결과가 없는 경우  반환할 SearchMemberUseCaseResponse#notExistSearchTarget를 추가하였습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
