### PR TITLE
[#8] Refactor: split member description

### DIFF
--- a/api/src/test/java/com/zzaug/api/web/controller/v1/description/MemberCheckDescription.java
+++ b/api/src/test/java/com/zzaug/api/web/controller/v1/description/MemberCheckDescription.java
@@ -1,0 +1,31 @@
+package com.zzaug.api.web.controller.v1.description;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class MemberCheckDescription {
+
+	public static FieldDescriptor[] checkMember() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.duplication").type(JsonFieldType.BOOLEAN).description("요청 증명(아이디) 중복 여부"),
+		};
+	}
+
+	public static FieldDescriptor[] emailAuth() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.duplication").type(JsonFieldType.BOOLEAN).description("요청 이메일 중복 여부"),
+		};
+	}
+
+	public static FieldDescriptor[] checkEmailAuth() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.authentication").type(JsonFieldType.BOOLEAN).description("인증 번호 확인 결과"),
+			fieldWithPath("data.tryCount").type(JsonFieldType.NUMBER).description("인증 번호 확인 시도 횟수"),
+		};
+	}
+}

--- a/api/src/test/java/com/zzaug/api/web/controller/v1/description/MemberDescription.java
+++ b/api/src/test/java/com/zzaug/api/web/controller/v1/description/MemberDescription.java
@@ -1,0 +1,50 @@
+package com.zzaug.api.web.controller.v1.description;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class MemberDescription {
+
+	public static FieldDescriptor[] updateMember() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("어세스 토큰"),
+		};
+	}
+
+	public static FieldDescriptor[] loginMember() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("어세스 토큰"),
+		};
+	}
+
+	public static FieldDescriptor[] readMember() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("멤버 아이디"),
+			fieldWithPath("data.certification").type(JsonFieldType.STRING).description("멤버 증명(아이디)"),
+			fieldWithPath("data.email").type(JsonFieldType.STRING).description("멤버 이메일"),
+			fieldWithPath("data.github").type(JsonFieldType.STRING).description("멤버 깃허브"),
+		};
+	}
+
+	public static FieldDescriptor[] searchMember() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("멤버 아이디"),
+			fieldWithPath("data.certification").type(JsonFieldType.STRING).description("멤버 증명(아이디)"),
+			fieldWithPath("data.email").type(JsonFieldType.STRING).description("멤버 이메일"),
+			fieldWithPath("data.github").type(JsonFieldType.STRING).description("멤버 깃허브"),
+		};
+	}
+
+	public static FieldDescriptor[] renewalToken() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("data"),
+			fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("어세스 토큰"),
+		};
+	}
+}

--- a/api/src/test/java/com/zzaug/api/web/controller/v1/member/MemberCheckControllerTest.java
+++ b/api/src/test/java/com/zzaug/api/web/controller/v1/member/MemberCheckControllerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -22,6 +21,7 @@ import com.zzaug.api.domain.member.usecase.CheckEmailAuthUseCase;
 import com.zzaug.api.domain.member.usecase.EmailAuthUseCase;
 import com.zzaug.api.web.controller.config.TestTokenUserDetailsService;
 import com.zzaug.api.web.controller.v1.description.Description;
+import com.zzaug.api.web.controller.v1.description.MemberCheckDescription;
 import com.zzaug.api.web.dto.member.CheckEmailAuthRequest;
 import java.util.UUID;
 import javax.servlet.http.Cookie;
@@ -35,8 +35,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -101,16 +99,7 @@ class MemberCheckControllerTest {
 												.requestParameters(
 														parameterWithName("certification").description("증명(아이디)"))
 												.responseSchema(Schema.schema("CheckMemberResponse"))
-												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.duplication")
-																			.type(JsonFieldType.BOOLEAN)
-																			.description("요청 증명(아이디) 중복 여부"),
-																}))
+												.responseFields(Description.success(MemberCheckDescription.checkMember()))
 												.build())));
 	}
 
@@ -144,16 +133,7 @@ class MemberCheckControllerTest {
 														parameterWithName("email").description("이메일"),
 														parameterWithName("nonce").description("인증번호"))
 												.responseSchema(Schema.schema("EmailAuthResponse"))
-												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.duplication")
-																			.type(JsonFieldType.BOOLEAN)
-																			.description("요청 이메일 중복 여부"),
-																}))
+												.responseFields(Description.success(MemberCheckDescription.emailAuth()))
 												.build())));
 	}
 
@@ -191,18 +171,7 @@ class MemberCheckControllerTest {
 												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("CheckEmailAuthResponse"))
 												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.authentication")
-																			.type(JsonFieldType.BOOLEAN)
-																			.description("인증 번호 확인 결과"),
-																	fieldWithPath("data.tryCount")
-																			.type(JsonFieldType.NUMBER)
-																			.description("인증 번호 확인 시도 횟수"),
-																}))
+														Description.success(MemberCheckDescription.checkEmailAuth()))
 												.build())));
 	}
 }

--- a/api/src/test/java/com/zzaug/api/web/controller/v1/member/MemberControllerTest.java
+++ b/api/src/test/java/com/zzaug/api/web/controller/v1/member/MemberControllerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.HeaderDescriptorWithType;
@@ -30,6 +29,7 @@ import com.zzaug.api.domain.member.usecase.SearchMemberUseCase;
 import com.zzaug.api.domain.member.usecase.UpdateMemberUseCase;
 import com.zzaug.api.web.controller.config.TestTokenUserDetailsService;
 import com.zzaug.api.web.controller.v1.description.Description;
+import com.zzaug.api.web.controller.v1.description.MemberDescription;
 import com.zzaug.api.web.dto.member.LoginRequest;
 import com.zzaug.api.web.dto.member.MemberSaveRequest;
 import com.zzaug.api.web.dto.member.MemberUpdateRequest;
@@ -46,8 +46,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -158,16 +156,7 @@ class MemberControllerTest {
 												.requestSchema(Schema.schema("UpdateMemberRequest"))
 												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("UpdateMemberResponse"))
-												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.accessToken")
-																			.type(JsonFieldType.STRING)
-																			.description("어세스 토큰"),
-																}))
+												.responseFields(Description.success(MemberDescription.updateMember()))
 												.build())));
 	}
 
@@ -188,14 +177,14 @@ class MemberControllerTest {
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
-								"UpdateMember",
+								"DeleteMember",
 								resource(
 										ResourceSnippetParameters.builder()
 												.description("회원 탈퇴를 진행합니다.")
 												.tag(TAG)
-												.requestSchema(Schema.schema("UpdateMemberRequest"))
+												.requestSchema(Schema.schema("DeleteMemberRequest"))
 												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
-												.responseSchema(Schema.schema("UpdateMemberResponse"))
+												.responseSchema(Schema.schema("DeleteMemberResponse"))
 												.responseFields(Description.deleted())
 												.build())));
 	}
@@ -232,16 +221,7 @@ class MemberControllerTest {
 												.requestSchema(Schema.schema("LoginMemberRequest"))
 												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("LoginMemberResponse"))
-												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.accessToken")
-																			.type(JsonFieldType.STRING)
-																			.description("어세스 토큰"),
-																}))
+												.responseFields(Description.success(MemberDescription.loginMember()))
 												.responseHeaders(
 														new HeaderDescriptorWithType[] {Description.setCookieHeader()})
 												.build())));
@@ -279,25 +259,7 @@ class MemberControllerTest {
 												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.pathParameters(parameterWithName("id").description("조회할 멤버의 아이디"))
 												.responseSchema(Schema.schema("ReadMemberResponse"))
-												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.id")
-																			.type(JsonFieldType.NUMBER)
-																			.description("멤버 아이디"),
-																	fieldWithPath("data.certification")
-																			.type(JsonFieldType.STRING)
-																			.description("멤버 증명(아이디)"),
-																	fieldWithPath("data.email")
-																			.type(JsonFieldType.STRING)
-																			.description("멤버 이메일"),
-																	fieldWithPath("data.github")
-																			.type(JsonFieldType.STRING)
-																			.description("멤버 깃허브"),
-																}))
+												.responseFields(Description.success(MemberDescription.readMember()))
 												.build())));
 	}
 
@@ -335,25 +297,7 @@ class MemberControllerTest {
 												.requestSchema(Schema.schema("SearchMemberRequest"))
 												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("SearchMemberResponse"))
-												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.id")
-																			.type(JsonFieldType.NUMBER)
-																			.description("멤버 아이디"),
-																	fieldWithPath("data.certification")
-																			.type(JsonFieldType.STRING)
-																			.description("멤버 증명(아이디)"),
-																	fieldWithPath("data.email")
-																			.type(JsonFieldType.STRING)
-																			.description("멤버 이메일"),
-																	fieldWithPath("data.github")
-																			.type(JsonFieldType.STRING)
-																			.description("멤버 깃허브"),
-																}))
+												.responseFields(Description.success(MemberDescription.searchMember()))
 												.build())));
 	}
 
@@ -378,24 +322,15 @@ class MemberControllerTest {
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
 						document(
-								"MemberToken",
+								"RenewalToken",
 								resource(
 										ResourceSnippetParameters.builder()
 												.description("토큰을 갱신합니다.")
 												.tag(TAG)
-												.requestSchema(Schema.schema("MemberTokenRequest"))
+												.requestSchema(Schema.schema("RenewalTokenRequest"))
 												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
-												.responseSchema(Schema.schema("MemberTokenResponse"))
-												.responseFields(
-														Description.success(
-																new FieldDescriptor[] {
-																	fieldWithPath("data")
-																			.type(JsonFieldType.OBJECT)
-																			.description("data"),
-																	fieldWithPath("data.accessToken")
-																			.type(JsonFieldType.STRING)
-																			.description("어세스 토큰"),
-																}))
+												.responseSchema(Schema.schema("RenewalTokenResponse"))
+												.responseFields(Description.success(MemberDescription.renewalToken()))
 												.responseHeaders(
 														new HeaderDescriptorWithType[] {Description.setCookieHeader()})
 												.build())));


### PR DESCRIPTION
🎫 연관 티켓
---
#8

🙏 작업
----
- 멤버 컨트롤러 테스트 응답 클래스 분리

💁‍♂️ 어떻게?
----
## 멤버 컨트롤러 테스트 응답 클래스 분리

기존의 컨트롤러 테스트에 포함되었던 응답에 관한 정의를 분리하였습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료
